### PR TITLE
`image_crop` duplikált package törlése `refilc_plus`-ból

### DIFF
--- a/refilc_plus/pubspec.yaml
+++ b/refilc_plus/pubspec.yaml
@@ -26,7 +26,6 @@ dependencies:
   dropdown_button2: ^2.3.9
   home_widget: ^0.7.0+1
   image_picker: ^1.0.7
-  image_crop: ^0.4.1
   animations: ^2.0.11
   flutter_svg: ^2.0.10+1
   flutter_dynamic_icon: ^2.1.0


### PR DESCRIPTION
Röviden, a `refilc`-ben már be lett töltve az `image_crop_plus` nevezetű package, aminek az ID-je `image_crop`. Viszont, volt egy ugyanilyen ID-jű package a `refilc_plus`-ban, aminek a package neve `image_crop` (mint az ID-ja). Ez egy package ID konfliktust idézett elő az iOS buildek folyamán, és teljesen megakadályozta a build-et.

Minden funkció ami a `image_crop`-ot használta tesztelve lett, és működik, mivel a package ID-t kitölti az `image_crop_plus`.